### PR TITLE
Feat/member update profile

### DIFF
--- a/src/main/java/com/example/newsfeed/member/dto/updatedto/UpdateMemberProfileRequestDto.java
+++ b/src/main/java/com/example/newsfeed/member/dto/updatedto/UpdateMemberProfileRequestDto.java
@@ -11,19 +11,13 @@ public class UpdateMemberProfileRequestDto {
 
     @NotBlank(message = "이름(실명)을 입력해주세요.")
     @Size(min = 1, max = 14, message = "이름은 1 ~ 14자 이어야 합니다.")
-    private final String name;
+    private String username;
 
     @NotBlank(message = "닉네임을 입력해주세요.")
     @Size(min = 1, max = 14, message = "닉네임은 1 ~ 14자 이어야 합니다.")
-    private final String nickname;
+    private String nickname;
 
-    private final String info;
-    private final String mbti;
+    private String info;
+    private String mbti;
 
-    public UpdateMemberProfileRequestDto(String name, String nickname, String info, String mbti) {
-        this.name = name;
-        this.nickname = nickname;
-        this.info = info;
-        this.mbti = mbti;
-    }
 }

--- a/src/main/java/com/example/newsfeed/member/entity/Member.java
+++ b/src/main/java/com/example/newsfeed/member/entity/Member.java
@@ -73,4 +73,12 @@ public class Member extends BaseDateTime {
         return new Member(id);
     }
 
+    // info, mbti 따로 업데이트 할 수 있게 만들어주는 조건문에 필요한 메서드(2개)
+    public void updateInfo(String info) {
+        this.info = info;
+    }
+
+    public void updateMbti(String mbti) {
+        this.mbti = mbti;
+    }
 }

--- a/src/main/java/com/example/newsfeed/member/service/MemberService.java
+++ b/src/main/java/com/example/newsfeed/member/service/MemberService.java
@@ -83,8 +83,8 @@ public class MemberService {
 
         // 프로필 수정
         member.profileUpdate(
-                savedMember.getUsername(),
-                savedMember.getNickname(),
+                requestDto.getUsername(),
+                requestDto.getNickname(),
                 savedMember.getInfo(),
                 savedMember.getMbti()
         );

--- a/src/main/java/com/example/newsfeed/member/service/MemberService.java
+++ b/src/main/java/com/example/newsfeed/member/service/MemberService.java
@@ -59,17 +59,27 @@ public class MemberService {
 
     @Transactional
     public UpdateMemberProfileResponseDto profileUpdate(Long memberId, UpdateMemberProfileRequestDto requestDto) {
-
         Member member = memberRepository.findMemberById(memberId).orElseThrow(
                 () -> new RuntimeException("id와 일치하는 유저가 없습니다.")
         );
 
+        // info, mbti 따로 업데이트 할 수 있게 만들어주는 조건문
+        // info, mbti 요청값이 없으면 이전에 있던 info,mbti 값 그대로 출력
+        if(requestDto.getInfo() != null){
+            member.updateInfo(requestDto.getInfo());
+        }
+        if(requestDto.getMbti() != null){
+            member.updateMbti(requestDto.getMbti());
+        }
+        // 프로필 수정 저장하는 쿼리
+        Member savedMember = memberRepository.save(member);
+
         // 프로필 수정
         member.profileUpdate(
-                requestDto.getName(),
-                requestDto.getNickname(),
-                requestDto.getInfo(),
-                requestDto.getMbti()
+                savedMember.getUsername(),
+                savedMember.getNickname(),
+                savedMember.getInfo(),
+                savedMember.getMbti()
         );
 
         log.info("프로필 수정 성공");

--- a/src/main/java/com/example/newsfeed/post/controller/PostController.java
+++ b/src/main/java/com/example/newsfeed/post/controller/PostController.java
@@ -1,5 +1,6 @@
 package com.example.newsfeed.post.controller;
 
+import com.example.newsfeed.global.annotation.LoginRequired;
 import com.example.newsfeed.global.entity.SessionMemberDto;
 import com.example.newsfeed.post.dto.PostCreateRequestDto;
 import com.example.newsfeed.post.dto.PostCreateResponseDto;
@@ -26,6 +27,7 @@ public class PostController {
     private final PostService postService;
 
     // 게시물 생성 (로그인 상태)
+    @LoginRequired
     @PostMapping
     public ResponseEntity<PostCreateResponseDto> createPost(
             @SessionAttribute(name = "member") SessionMemberDto session,

--- a/src/main/java/com/example/newsfeed/post/controller/PostController.java
+++ b/src/main/java/com/example/newsfeed/post/controller/PostController.java
@@ -25,7 +25,8 @@ import java.util.List;
 public class PostController {
     private final PostService postService;
 
-    @PostMapping("/posts")
+    // 게시물 생성 (로그인 상태)
+    @PostMapping
     public ResponseEntity<PostCreateResponseDto> createPost(
             @SessionAttribute(name = "member") SessionMemberDto session,
             @Valid @RequestBody PostCreateRequestDto requestDto

--- a/src/main/java/com/example/newsfeed/post/controller/PostController.java
+++ b/src/main/java/com/example/newsfeed/post/controller/PostController.java
@@ -6,6 +6,7 @@ import com.example.newsfeed.post.dto.PostCreateResponseDto;
 import com.example.newsfeed.post.service.PostService;
 import com.example.newsfeed.post.dto.PostResponseDto;
 import com.example.newsfeed.post.service.PostService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -23,10 +24,10 @@ import java.util.List;
 public class PostController {
     private final PostService postService;
 
-    @PostMapping("/members/{memberId}/posts")
+    @PostMapping("/posts")
     public ResponseEntity<PostCreateResponseDto> createPost(
             @SessionAttribute(name = "member") SessionMemberDto session,
-            @RequestBody PostCreateRequestDto requestDto
+            @Valid @RequestBody PostCreateRequestDto requestDto
     ) {
 
         log.info("게시물 생성 API 호출");

--- a/src/main/java/com/example/newsfeed/post/service/PostService.java
+++ b/src/main/java/com/example/newsfeed/post/service/PostService.java
@@ -23,8 +23,11 @@ public class PostService extends BaseDateTime {
 
     @Transactional
     public PostCreateResponseDto createPost(SessionMemberDto session, PostCreateRequestDto requestDto) {
-        Member member = Member.fromMemberId(session.getId());
-        Post post = new Post(requestDto.getImage(), requestDto.getContents(), member);
+        Member member = memberRepository.findMemberById(session.getId()).orElseThrow(
+                () -> new RuntimeException("id에 맞는 멤버가 없습니다.")
+        );
+        Member findMember = Member.fromMemberId(session.getId());
+        Post post = new Post(requestDto.getImage(), requestDto.getContents(), findMember);
         Post savedPost = postRepository.save(post);
 
         log.info("게시물 생성 성공");

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -2,10 +2,10 @@ spring.application.name=news-feed
 
 spring.datasource.url=jdbc:mysql://localhost:3306/newsfeed
 spring.datasource.username=root
-spring.datasource.password=Plqafgh12!
+spring.datasource.password=Gustmd2791!
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 
-spring.jpa.hibernate.ddl-auto=update
+spring.jpa.hibernate.ddl-auto=create
 spring.jpa.properties.hibernate.show_sql=true
 spring.jpa.properties.hibernate.format_sql=true
 spring.jpa.properties.hibernate.use_sql_comments=true


### PR DESCRIPTION
Feat(Member) : 따로 업데이트 기능추가, 게시물생성 오류해결
info, mbti를 따로 업데이트 할 수 있게 조건문 추가
-> info, mbti 요청값이 없으면 이전에 가지고 있는 info,mbti 값 그대로 출력
게시물 생성시 nickname이 null으로 출력되는 오류 수정

Fix(member): MemberService , PostController 클래스 코드수정
MemberService : 프로필 수정시 username, nickname이 바뀌지 않고 회원가입할 때 값 그대로 출력되는 오류 수정
PostController : 게시물 생성url  /posts 삭제,  파라미터안 request 앞에 @Valid 추가