### PR TITLE
Feat/follow delete

### DIFF
--- a/src/main/java/com/example/newsfeed/follow/controller/FollowController.java
+++ b/src/main/java/com/example/newsfeed/follow/controller/FollowController.java
@@ -3,8 +3,7 @@ package com.example.newsfeed.follow.controller;
 import com.example.newsfeed.follow.service.FollowService;
 import com.example.newsfeed.global.annotation.LoginRequired;
 import com.example.newsfeed.global.entity.SessionMemberDto;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpSession;
+import com.example.newsfeed.member.dto.MemberListResponseDto;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -12,7 +11,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
-import org.springframework.web.bind.annotation.*;
 
 @Slf4j
 @RestController

--- a/src/main/java/com/example/newsfeed/follow/controller/FollowController.java
+++ b/src/main/java/com/example/newsfeed/follow/controller/FollowController.java
@@ -9,10 +9,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Slf4j
 @RestController
@@ -26,16 +23,19 @@ public class FollowController {
     @PostMapping("/{memberId}")
     public ResponseEntity<Void> createFollow(
             @PathVariable Long memberId,
-            HttpServletRequest httpServletRequest
+            @SessionAttribute(name = "member") SessionMemberDto session
     ) {
-        Long followerId = getMemberIdBySession(httpServletRequest);
-        followService.createFollow(followerId, memberId);
+        followService.createFollow(session.getId(), memberId);
         return new ResponseEntity<>(HttpStatus.OK);
     }
 
-    private Long getMemberIdBySession(HttpServletRequest httpServletRequest) {
-        HttpSession session = httpServletRequest.getSession(false);
-        SessionMemberDto sessionMemberDto = (SessionMemberDto) session.getAttribute("member");
-        return sessionMemberDto.getId();
+    @LoginRequired
+    @DeleteMapping("/{memberId}")
+    public ResponseEntity<Void> deleteFollow(
+            @PathVariable Long memberId,
+            @SessionAttribute(name = "member") SessionMemberDto session
+    ) {
+        followService.deleteFollow(session.getId(), memberId);
+        return new ResponseEntity<>(HttpStatus.OK);
     }
 }

--- a/src/main/java/com/example/newsfeed/follow/controller/FollowController.java
+++ b/src/main/java/com/example/newsfeed/follow/controller/FollowController.java
@@ -3,13 +3,14 @@ package com.example.newsfeed.follow.controller;
 import com.example.newsfeed.follow.service.FollowService;
 import com.example.newsfeed.global.annotation.LoginRequired;
 import com.example.newsfeed.global.entity.SessionMemberDto;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpSession;
+import com.example.newsfeed.member.dto.MemberListResponseDto;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @Slf4j
 @RestController
@@ -37,5 +38,14 @@ public class FollowController {
     ) {
         followService.deleteFollow(session.getId(), memberId);
         return new ResponseEntity<>(HttpStatus.OK);
+    }
+
+    @LoginRequired
+    @GetMapping
+    public ResponseEntity<List<MemberListResponseDto>> findAllFollowerMembers(
+            @SessionAttribute(name = "member") SessionMemberDto session
+    ) {
+        List<MemberListResponseDto> responseDtoList = followService.findAllFollowerMembers(session.getId());
+        return new ResponseEntity<>(responseDtoList, HttpStatus.OK);
     }
 }

--- a/src/main/java/com/example/newsfeed/follow/entity/Follow.java
+++ b/src/main/java/com/example/newsfeed/follow/entity/Follow.java
@@ -41,7 +41,7 @@ public class Follow extends BaseDateTime{
         this.followStatus = FollowStatus.FOLLOWING;
     }
 
-    public void updateFollowStatusFalse() {
-        this.followStatus = FollowStatus.NOT_FOLLOWING;
+    public void updateFollowStatus(FollowStatus followStatus) {
+        this.followStatus = followStatus;
     }
 }

--- a/src/main/java/com/example/newsfeed/follow/entity/Follow.java
+++ b/src/main/java/com/example/newsfeed/follow/entity/Follow.java
@@ -40,4 +40,8 @@ public class Follow extends BaseDateTime{
         this.followingMember = followingMember;
         this.followStatus = FollowStatus.FOLLOWING;
     }
+
+    public void updateFollowStatusFalse() {
+        this.followStatus = FollowStatus.NOT_FOLLOWING;
+    }
 }

--- a/src/main/java/com/example/newsfeed/follow/entity/FollowStatus.java
+++ b/src/main/java/com/example/newsfeed/follow/entity/FollowStatus.java
@@ -1,10 +1,14 @@
 package com.example.newsfeed.follow.entity;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
 // 친구상태로의 코드 확장성을 고려하기위해 enum 자료형으로 팔로우 상태 관리
+@Getter
+@RequiredArgsConstructor
 public enum FollowStatus {
     NOT_FOLLOWING(false),
     FOLLOWING(true);
 
-    FollowStatus(boolean status) {
-    }
+    private final boolean status;
 }

--- a/src/main/java/com/example/newsfeed/follow/repository/FollowRepository.java
+++ b/src/main/java/com/example/newsfeed/follow/repository/FollowRepository.java
@@ -13,4 +13,6 @@ public interface FollowRepository extends JpaRepository<Follow, Long> {
     Optional<Follow> findFollowByFollowerMemberAndFollowingMember(Member followerMember, Member findFollowingMember);
 
     List<Follow> findByFollowerMemberId(Long id);
+
+    long countByFollowingMemberId(Long id);
 }

--- a/src/main/java/com/example/newsfeed/follow/repository/FollowRepository.java
+++ b/src/main/java/com/example/newsfeed/follow/repository/FollowRepository.java
@@ -4,6 +4,10 @@ import com.example.newsfeed.follow.entity.Follow;
 import com.example.newsfeed.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface FollowRepository extends JpaRepository<Follow, Long> {
     boolean existsFollowByFollowerMemberAndFollowingMember(Member followerMember, Member findFollowingMember);
+
+    Optional<Follow> findFollowByFollowerMemberAndFollowingMember(Member followerMember, Member findFollowingMember);
 }

--- a/src/main/java/com/example/newsfeed/follow/repository/FollowRepository.java
+++ b/src/main/java/com/example/newsfeed/follow/repository/FollowRepository.java
@@ -1,18 +1,23 @@
 package com.example.newsfeed.follow.repository;
 
 import com.example.newsfeed.follow.entity.Follow;
-import com.example.newsfeed.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
 
 public interface FollowRepository extends JpaRepository<Follow, Long> {
-    boolean existsFollowByFollowerMemberAndFollowingMember(Member followerMember, Member findFollowingMember);
-
-    Optional<Follow> findFollowByFollowerMemberAndFollowingMember(Member followerMember, Member findFollowingMember);
-
-    List<Follow> findByFollowerMemberId(Long id);
 
     long countByFollowingMemberId(Long id);
+
+    @Query("SELECT f FROM Follow f WHERE f.followerMember.id = :followerId AND f.followingMember.id = :followingId")
+    Optional<Follow> findByFollowerIdAndFollowingId(
+            @Param("followerId") Long followId,
+            @Param("followingId") Long followingId
+    );
+
+    @Query("SELECT f FROM Follow f WHERE f.followerMember.id = :followerId AND f.followStatus = 'FOLLOWING'")
+    List<Follow> findByFollowerIdAndStatus(@Param("followerId") Long followerId);
 }

--- a/src/main/java/com/example/newsfeed/follow/repository/FollowRepository.java
+++ b/src/main/java/com/example/newsfeed/follow/repository/FollowRepository.java
@@ -4,10 +4,13 @@ import com.example.newsfeed.follow.entity.Follow;
 import com.example.newsfeed.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface FollowRepository extends JpaRepository<Follow, Long> {
     boolean existsFollowByFollowerMemberAndFollowingMember(Member followerMember, Member findFollowingMember);
 
     Optional<Follow> findFollowByFollowerMemberAndFollowingMember(Member followerMember, Member findFollowingMember);
+
+    List<Follow> findByFollowerMemberId(Long id);
 }

--- a/src/main/java/com/example/newsfeed/follow/service/FollowService.java
+++ b/src/main/java/com/example/newsfeed/follow/service/FollowService.java
@@ -3,6 +3,7 @@ package com.example.newsfeed.follow.service;
 import com.example.newsfeed.follow.entity.Follow;
 import com.example.newsfeed.follow.entity.FollowStatus;
 import com.example.newsfeed.follow.repository.FollowRepository;
+import com.example.newsfeed.member.dto.MemberListResponseDto;
 import com.example.newsfeed.member.entity.Member;
 import com.example.newsfeed.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
@@ -10,6 +11,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Slf4j
 @Service
@@ -59,6 +62,15 @@ public class FollowService {
         }
 
         findFollow.updateFollowStatusFalse();
+    }
+
+    public List<MemberListResponseDto> findAllFollowerMembers(Long id) {
+        List<Follow> followList = followRepository.findByFollowerMemberId(id);
+
+        return followList.stream()
+                .filter(follow -> follow.getFollowStatus() == FollowStatus.FOLLOWING)
+                .map(follow -> new MemberListResponseDto(follow.getFollowingMember()))
+                .toList();
     }
 
     private Follow findFollowByFollowerMemberAndFollowingMemberOrElseThrow(Member followerMember, Member followingMember) {

--- a/src/main/java/com/example/newsfeed/follow/service/FollowService.java
+++ b/src/main/java/com/example/newsfeed/follow/service/FollowService.java
@@ -5,14 +5,13 @@ import com.example.newsfeed.follow.entity.FollowStatus;
 import com.example.newsfeed.follow.repository.FollowRepository;
 import com.example.newsfeed.member.dto.MemberListResponseDto;
 import com.example.newsfeed.member.entity.Member;
-import com.example.newsfeed.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -21,56 +20,45 @@ import java.util.stream.Collectors;
 public class FollowService {
 
     private final FollowRepository followRepository;
-    private final MemberService memberService;
 
     @Transactional
     public void createFollow(Long followerId, Long followingId) {
 
-        if (followingId.equals(followerId)) {
-            throw new RuntimeException("본인을 팔로우 할 수 없다.");
-        }
+        validateEqualsFollowerAndFollowing(followerId, followingId);
 
-        // 팔로워와 팔로잉을 조회
-        Member followerMember = memberService.findActiveMemberByIdOrElseThrow(followerId);
-        Member findFollowingMember = memberService.findActiveMemberByIdOrElseThrow(followingId);
+        Optional<Follow> optionalFollow = followRepository.findByFollowerIdAndFollowingId(followerId, followingId);
 
-        if (followRepository.existsFollowByFollowerMemberAndFollowingMember(followerMember, findFollowingMember)) {
-            throw new RuntimeException("이미 팔로우를 한 유저 입니다.");
-        }
+        if (optionalFollow.isPresent()) {
+            Follow findFollow = optionalFollow.get();
 
-        try {
-            Follow follow = new Follow(followerMember, findFollowingMember);       // followStatus 를 true 로 자동 생성
-            followRepository.save(follow);
-        } catch (DataIntegrityViolationException e) {
-            throw new RuntimeException("이미 팔로우를 한 유저 입니다.");
+            if (findFollow.getFollowStatus() == FollowStatus.FOLLOWING) {
+                throw new RuntimeException("이미 팔로우를 한 상태입니다.");
+            }
+            findFollow.updateFollowStatus(FollowStatus.FOLLOWING);
+            return;
         }
+        Follow follow = new Follow(new Member(followerId), new Member(followingId));
+        followRepository.save(follow);
     }
 
     @Transactional
     public void deleteFollow(Long followerId, Long followingId) {
-        if (followingId.equals(followerId)) {
-            throw new RuntimeException("본인을 언팔로우 할 수 없다.");
-        }
 
-        // 팔로워와 팔로잉을 조회
-        Member followerMember = memberService.findActiveMemberByIdOrElseThrow(followerId);
-        Member findFollowingMember = memberService.findActiveMemberByIdOrElseThrow(followingId);
+        validateEqualsFollowerAndFollowing(followerId, followingId);
 
-        Follow findFollow = findFollowByFollowerMemberAndFollowingMemberOrElseThrow(followerMember, findFollowingMember);
+        Follow findFollow = findByFollowerIdAndFollowingIdOrElseThrow(followerId, followingId);
 
         if (findFollow.getFollowStatus() == FollowStatus.NOT_FOLLOWING) {
             throw new RuntimeException("이미 언팔로우를 한 유저 입니다.");
         }
-
-        findFollow.updateFollowStatusFalse();
+        findFollow.updateFollowStatus(FollowStatus.NOT_FOLLOWING);
     }
 
     @Transactional(readOnly = true)
     public List<MemberListResponseDto> findAllFollowerMembers(Long id) {
-        List<Follow> followList = followRepository.findByFollowerMemberId(id);
+        List<Follow> followList = followRepository.findByFollowerIdAndStatus(id);
 
         return followList.stream()
-                .filter(follow -> follow.getFollowStatus() == FollowStatus.FOLLOWING)
                 .map(Follow::getFollowingMember)
                 .filter(member -> !member.isDeleted())
                 .map(member -> {
@@ -80,9 +68,15 @@ public class FollowService {
                 .collect(Collectors.toList());
     }
 
-    private Follow findFollowByFollowerMemberAndFollowingMemberOrElseThrow(Member followerMember, Member followingMember) {
-        return followRepository.findFollowByFollowerMemberAndFollowingMember(followerMember, followingMember).orElseThrow(
+    private Follow findByFollowerIdAndFollowingIdOrElseThrow(Long followerId, Long followingId) {
+        return followRepository.findByFollowerIdAndFollowingId(followerId, followingId).orElseThrow(
                 () -> new RuntimeException("팔로우 내용을 찾을 수 없습니다.")
         );
+    }
+
+    private void validateEqualsFollowerAndFollowing(Long followerId, Long followingId) {
+        if (followingId.equals(followerId)) {
+            throw new RuntimeException("본인을 팔로우/언팔로우 할 수 없다.");
+        }
     }
 }

--- a/src/main/java/com/example/newsfeed/like/controller/PostLikeController.java
+++ b/src/main/java/com/example/newsfeed/like/controller/PostLikeController.java
@@ -1,5 +1,6 @@
 package com.example.newsfeed.like.controller;
 
+import com.example.newsfeed.global.annotation.LoginRequired;
 import com.example.newsfeed.global.entity.SessionMemberDto;
 import com.example.newsfeed.like.service.LikeService;
 import lombok.RequiredArgsConstructor;
@@ -15,6 +16,7 @@ public class PostLikeController implements LikeController{
     private final LikeService likeService;
 
     @Override
+    @LoginRequired
     @PostMapping("/{postId}/likes")
     public ResponseEntity<Void> createLike(
             @PathVariable Long postId,
@@ -25,6 +27,7 @@ public class PostLikeController implements LikeController{
     }
 
     @Override
+    @LoginRequired
     @DeleteMapping("/{postId}/likes")
     public ResponseEntity<Void> deleteLike(
             @PathVariable Long postId,

--- a/src/main/java/com/example/newsfeed/like/entity/LikeStatus.java
+++ b/src/main/java/com/example/newsfeed/like/entity/LikeStatus.java
@@ -1,7 +1,9 @@
 package com.example.newsfeed.like.entity;
 
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
+@Getter
 @RequiredArgsConstructor
 public enum LikeStatus {
     NOT_LIKE(false),

--- a/src/main/java/com/example/newsfeed/like/service/PostLikeService.java
+++ b/src/main/java/com/example/newsfeed/like/service/PostLikeService.java
@@ -4,7 +4,6 @@ import com.example.newsfeed.like.entity.LikeStatus;
 import com.example.newsfeed.like.entity.PostLike;
 import com.example.newsfeed.like.repository.PostLikeRepository;
 import com.example.newsfeed.member.entity.Member;
-import com.example.newsfeed.member.service.MemberService;
 import com.example.newsfeed.post.entity.Post;
 import com.example.newsfeed.post.service.PostService;
 import lombok.RequiredArgsConstructor;
@@ -19,7 +18,6 @@ public class PostLikeService implements LikeService{
 
     private final PostLikeRepository postLikeRepository;
     private final PostService postService;
-    private final MemberService memberService;
 
     @Override
     @Transactional

--- a/src/main/java/com/example/newsfeed/member/dto/MemberListResponseDto.java
+++ b/src/main/java/com/example/newsfeed/member/dto/MemberListResponseDto.java
@@ -12,12 +12,12 @@ public class MemberListResponseDto {
     private Long id;
     private String nickname;
     private String email;
-    private int followerCount;
+    private long followerCount;
 
-    public MemberListResponseDto(Member member) {
+    public MemberListResponseDto(Member member, long followerCount) {
         this.id = member.getId();
         this.nickname = member.getNickname();
         this.email = member.getEmail();
-        // todo: 양방향을 사용할 수 있으므로 followerCount는 null
+        this.followerCount = followerCount;
     }
 }

--- a/src/main/java/com/example/newsfeed/member/dto/MemberListResponseDto.java
+++ b/src/main/java/com/example/newsfeed/member/dto/MemberListResponseDto.java
@@ -1,0 +1,23 @@
+package com.example.newsfeed.member.dto;
+
+import com.example.newsfeed.global.annotation.LoginRequired;
+import com.example.newsfeed.member.entity.Member;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@AllArgsConstructor
+public class MemberListResponseDto {
+    private Long id;
+    private String nickname;
+    private String email;
+    private int followerCount;
+
+    public MemberListResponseDto(Member member) {
+        this.id = member.getId();
+        this.nickname = member.getNickname();
+        this.email = member.getEmail();
+        // todo: 양방향을 사용할 수 있으므로 followerCount는 null
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -5,7 +5,7 @@ spring.datasource.username=root
 spring.datasource.password=jieun4711@
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 
-spring.jpa.hibernate.ddl-auto=create
+spring.jpa.hibernate.ddl-auto=update
 spring.jpa.properties.hibernate.show_sql=true
 spring.jpa.properties.hibernate.format_sql=true
 spring.jpa.properties.hibernate.use_sql_comments=true

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -5,7 +5,7 @@ spring.datasource.username=root
 spring.datasource.password=jieun4711@
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 
-spring.jpa.hibernate.ddl-auto=update
+spring.jpa.hibernate.ddl-auto=create
 spring.jpa.properties.hibernate.show_sql=true
 spring.jpa.properties.hibernate.format_sql=true
 spring.jpa.properties.hibernate.use_sql_comments=true


### PR DESCRIPTION
팔로우 기능에 이어 언팔로우 기능을 사용했습니다.
팔로우/언팔로우 코드 작성내용이 비슷하기 때문에 한 메서드에 토글방법을 사용하자는 의견이 나오긴 했지만, 나중에 맞팔로우 상태 설정이나, 친구기능으로의 확장성을 고려할 때 따로 메서드를 구현하는 것이 좋을 것 같다고 생각해 팔로우, 언팔로우 기능을 각각 구현했습니다.

조회의 경우 내가 팔로우 하고 있는 사람을 조회할 수 있으며, 내가 팔로우 한 유저가 얼마나 많은 팔로우를 받고 있는지(팔로잉) followCount까지 출력할 수 있습니다.
원래는 Member 엔티티에서 양방향으로 구현하려고 했다가, DB기능으로 갯수를 출력할 수 있다는 걸 알게되었습니다.
stream의 경우 조금 복잡해 보일 수 있겠으나,
Follow -> Member -> MemberListResponseDto로 변환하는 과정이라고 생각하시면 될 것 같습니다.