### PR TITLE
Feat/post like

### DIFF
--- a/src/main/java/com/example/newsfeed/like/controller/LikeController.java
+++ b/src/main/java/com/example/newsfeed/like/controller/LikeController.java
@@ -1,0 +1,14 @@
+package com.example.newsfeed.like.controller;
+
+import com.example.newsfeed.global.entity.SessionMemberDto;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.SessionAttribute;
+import org.springframework.web.servlet.function.EntityResponse;
+
+public interface LikeController {
+
+    ResponseEntity<Void> createLike(Long id, SessionMemberDto session);
+
+    ResponseEntity<Void> deleteLike(Long id, SessionMemberDto session);
+}

--- a/src/main/java/com/example/newsfeed/like/controller/LikeController.java
+++ b/src/main/java/com/example/newsfeed/like/controller/LikeController.java
@@ -2,9 +2,6 @@ package com.example.newsfeed.like.controller;
 
 import com.example.newsfeed.global.entity.SessionMemberDto;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.SessionAttribute;
-import org.springframework.web.servlet.function.EntityResponse;
 
 public interface LikeController {
 

--- a/src/main/java/com/example/newsfeed/like/controller/PostLikeController.java
+++ b/src/main/java/com/example/newsfeed/like/controller/PostLikeController.java
@@ -1,0 +1,37 @@
+package com.example.newsfeed.like.controller;
+
+import com.example.newsfeed.global.entity.SessionMemberDto;
+import com.example.newsfeed.like.service.LikeService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.function.EntityResponse;
+
+@RestController
+@RequestMapping("/like/posts")
+@RequiredArgsConstructor
+public class PostLikeController implements LikeController{
+
+    private final LikeService likeService;
+
+    @Override
+    @PostMapping("/{postId}")
+    public ResponseEntity<Void> createLike(
+            @PathVariable Long postId,
+            @SessionAttribute(name = "member") SessionMemberDto session
+    ) {
+        likeService.createLike(session.getId(), postId);
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
+
+    @Override
+    @DeleteMapping("/{postId}")
+    public ResponseEntity<Void> deleteLike(
+            @PathVariable Long postId,
+            @SessionAttribute(name = "member") SessionMemberDto session
+    ) {
+        likeService.deleteLike(session.getId(), postId);
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
+}

--- a/src/main/java/com/example/newsfeed/like/controller/PostLikeController.java
+++ b/src/main/java/com/example/newsfeed/like/controller/PostLikeController.java
@@ -6,7 +6,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.servlet.function.EntityResponse;
 
 @RestController
 @RequestMapping("/like/posts")

--- a/src/main/java/com/example/newsfeed/like/controller/PostLikeController.java
+++ b/src/main/java/com/example/newsfeed/like/controller/PostLikeController.java
@@ -8,14 +8,14 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/like/posts")
+@RequestMapping("/posts")
 @RequiredArgsConstructor
 public class PostLikeController implements LikeController{
 
     private final LikeService likeService;
 
     @Override
-    @PostMapping("/{postId}")
+    @PostMapping("/{postId}/likes")
     public ResponseEntity<Void> createLike(
             @PathVariable Long postId,
             @SessionAttribute(name = "member") SessionMemberDto session
@@ -25,7 +25,7 @@ public class PostLikeController implements LikeController{
     }
 
     @Override
-    @DeleteMapping("/{postId}")
+    @DeleteMapping("/{postId}/likes")
     public ResponseEntity<Void> deleteLike(
             @PathVariable Long postId,
             @SessionAttribute(name = "member") SessionMemberDto session

--- a/src/main/java/com/example/newsfeed/like/entity/CommentLike.java
+++ b/src/main/java/com/example/newsfeed/like/entity/CommentLike.java
@@ -1,0 +1,35 @@
+package com.example.newsfeed.like.entity;
+
+import com.example.newsfeed.follow.entity.FollowStatus;
+import com.example.newsfeed.global.entity.BaseDateTime;
+import com.example.newsfeed.member.entity.Member;
+import com.example.newsfeed.post.entity.Post;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+//@Entity
+//@Getter
+//@NoArgsConstructor
+//@Table(name = "comment_like")
+//public class CommentLike extends BaseDateTime {
+//
+//    @Id
+//    @GeneratedValue(strategy = GenerationType.IDENTITY)
+//    private Long id;
+//
+//    @Setter
+//    @ManyToOne(fetch = FetchType.LAZY)
+//    @JoinColumn(name = "member_id")
+//    private Member Member;
+//
+//    @Setter
+//    @ManyToOne(fetch = FetchType.LAZY)
+//    @JoinColumn(name = "comment_id")
+//    private Comment comment;
+//
+//    @Enumerated(EnumType.STRING)
+//    private LikeStatus likeStatus;
+//
+//}

--- a/src/main/java/com/example/newsfeed/like/entity/LikeStatus.java
+++ b/src/main/java/com/example/newsfeed/like/entity/LikeStatus.java
@@ -1,9 +1,11 @@
 package com.example.newsfeed.like.entity;
 
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
 public enum LikeStatus {
     NOT_LIKE(false),
     LIKE(true);
 
-    LikeStatus(boolean status) {
-    }
+    private final boolean status;
 }

--- a/src/main/java/com/example/newsfeed/like/entity/LikeStatus.java
+++ b/src/main/java/com/example/newsfeed/like/entity/LikeStatus.java
@@ -1,0 +1,9 @@
+package com.example.newsfeed.like.entity;
+
+public enum LikeStatus {
+    NOT_LIKE(false),
+    LIKE(true);
+
+    LikeStatus(boolean status) {
+    }
+}

--- a/src/main/java/com/example/newsfeed/like/entity/PostLike.java
+++ b/src/main/java/com/example/newsfeed/like/entity/PostLike.java
@@ -1,6 +1,5 @@
 package com.example.newsfeed.like.entity;
 
-import com.example.newsfeed.follow.entity.FollowStatus;
 import com.example.newsfeed.global.entity.BaseDateTime;
 import com.example.newsfeed.member.entity.Member;
 import com.example.newsfeed.post.entity.Post;

--- a/src/main/java/com/example/newsfeed/like/entity/PostLike.java
+++ b/src/main/java/com/example/newsfeed/like/entity/PostLike.java
@@ -34,6 +34,7 @@ public class PostLike extends BaseDateTime {
     public PostLike(Member member, Post post) {
         this.member = member;
         this.post = post;
+        this.likeStatus = LikeStatus.LIKE;
     }
 
     public void updateLikeStatus(LikeStatus likeStatus) {

--- a/src/main/java/com/example/newsfeed/like/entity/PostLike.java
+++ b/src/main/java/com/example/newsfeed/like/entity/PostLike.java
@@ -22,7 +22,7 @@ public class PostLike extends BaseDateTime {
     @Setter
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
-    private Member Member;
+    private Member member;
 
     @Setter
     @ManyToOne(fetch = FetchType.LAZY)
@@ -31,5 +31,14 @@ public class PostLike extends BaseDateTime {
 
     @Enumerated(EnumType.STRING)
     private LikeStatus likeStatus;
+
+    public PostLike(Member member, Post post) {
+        this.member = member;
+        this.post = post;
+    }
+
+    public void updateLikeStatus(LikeStatus likeStatus) {
+        this.likeStatus = likeStatus;
+    }
 
 }

--- a/src/main/java/com/example/newsfeed/like/entity/PostLike.java
+++ b/src/main/java/com/example/newsfeed/like/entity/PostLike.java
@@ -1,0 +1,35 @@
+package com.example.newsfeed.like.entity;
+
+import com.example.newsfeed.follow.entity.FollowStatus;
+import com.example.newsfeed.global.entity.BaseDateTime;
+import com.example.newsfeed.member.entity.Member;
+import com.example.newsfeed.post.entity.Post;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@Table(name = "post_like")
+public class PostLike extends BaseDateTime {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Setter
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member Member;
+
+    @Setter
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id")
+    private Post post;
+
+    @Enumerated(EnumType.STRING)
+    private LikeStatus likeStatus;
+
+}

--- a/src/main/java/com/example/newsfeed/like/repository/PostLikeRepository.java
+++ b/src/main/java/com/example/newsfeed/like/repository/PostLikeRepository.java
@@ -1,11 +1,11 @@
 package com.example.newsfeed.like.repository;
 
-import com.example.newsfeed.follow.entity.Follow;
 import com.example.newsfeed.like.entity.PostLike;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
 public interface PostLikeRepository extends JpaRepository<PostLike, Long> {
-    Optional<PostLike> findPostLikeByMember_IdAndPost_Id(Long memberId, Long postId);
+
+    Optional<PostLike> findByMemberIdAndPostId(Long memberId, Long postId);
 }

--- a/src/main/java/com/example/newsfeed/like/repository/PostLikeRepository.java
+++ b/src/main/java/com/example/newsfeed/like/repository/PostLikeRepository.java
@@ -1,0 +1,11 @@
+package com.example.newsfeed.like.repository;
+
+import com.example.newsfeed.follow.entity.Follow;
+import com.example.newsfeed.like.entity.PostLike;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface PostLikeRepository extends JpaRepository<PostLike, Long> {
+    Optional<PostLike> findPostLikeByMember_IdAndPost_Id(Long memberId, Long postId);
+}

--- a/src/main/java/com/example/newsfeed/like/service/LikeService.java
+++ b/src/main/java/com/example/newsfeed/like/service/LikeService.java
@@ -1,0 +1,8 @@
+package com.example.newsfeed.like.service;
+
+public interface LikeService {
+
+    void createLike(Long memberId, Long Id);
+
+    void deleteLike(Long memberId, Long id);
+}

--- a/src/main/java/com/example/newsfeed/like/service/PostLikeService.java
+++ b/src/main/java/com/example/newsfeed/like/service/PostLikeService.java
@@ -1,0 +1,84 @@
+package com.example.newsfeed.like.service;
+
+import com.example.newsfeed.like.entity.LikeStatus;
+import com.example.newsfeed.like.entity.PostLike;
+import com.example.newsfeed.like.repository.PostLikeRepository;
+import com.example.newsfeed.member.entity.Member;
+import com.example.newsfeed.member.service.MemberService;
+import com.example.newsfeed.post.entity.Post;
+import com.example.newsfeed.post.service.PostService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class PostLikeService implements LikeService{
+
+    private final PostLikeRepository postLikeRepository;
+    private final PostService postService;
+    private final MemberService memberService;
+
+    @Override
+    @Transactional
+    public void createLike(Long memberId, Long postId) {
+
+        Post findPost = postService.findPostByIdOrElseThrow(postId);
+
+        if (findPost.getMember().getId().equals(memberId)) {
+            throw new RuntimeException("본인이 작성한 게시글에 좋아요를 누를 수 없다.");
+        }
+
+        // post-like 테이블에 좋아요 기록이 있는지 없는지 확인
+        // 있을때 상태가 true 이다 --> 이미 좋아요를 누른 상태
+        // 있을때 상태가 false 이다 --> 좋아요를 해제한 상태(좋아요를 누를 수 있음)
+        // 없을때 --> 처음 좋아요를 누른 상태 (좋아요를 누를 수 있음)
+
+        Optional<PostLike> optionalPostLike = postLikeRepository.findPostLikeByMember_IdAndPost_Id(memberId, postId);
+
+        if (optionalPostLike.isPresent()) {
+            PostLike findPostLike = optionalPostLike.get();
+
+            if (findPostLike.getLikeStatus() == LikeStatus.LIKE) {
+                throw new RuntimeException("이미 좋아요를 누른 상태입니다.");
+            }
+
+            findPostLike.updateLikeStatus(LikeStatus.LIKE);
+            return;
+        }
+
+        Member findMember = memberService.findActiveMemberByIdOrElseThrow(memberId);
+
+        PostLike postLike = new PostLike(findMember, findPost);
+        postLikeRepository.save(postLike);
+    }
+
+    @Override
+    @Transactional
+    public void deleteLike(Long memberId, Long postId) {
+
+        Post findPost = postService.findPostByIdOrElseThrow(postId);
+
+        if (findPost.getMember().getId().equals(memberId)) {
+            throw new RuntimeException("본인이 작성한 게시글에 좋아요를 해제할 수 없다.");
+        }
+
+        Member findMember = memberService.findActiveMemberByIdOrElseThrow(memberId);
+
+        PostLike findPostLike = findPostLikeByMember_IdAndPost_IdOrElseThrow(findMember.getId(), findPost.getId());
+
+        if (findPostLike.getLikeStatus() == LikeStatus.NOT_LIKE) {
+            throw new RuntimeException("이미 좋아요 해제를 한 게시물 입니다.");
+        }
+
+        findPostLike.updateLikeStatus(LikeStatus.NOT_LIKE);
+    }
+
+    private PostLike findPostLikeByMember_IdAndPost_IdOrElseThrow(Long memberId, Long postId) {
+        return postLikeRepository.findPostLikeByMember_IdAndPost_Id(memberId, postId).orElseThrow(
+                () -> new RuntimeException("좋아요 기록 존재하지 않음")
+        );
+    }
+}

--- a/src/main/java/com/example/newsfeed/like/service/PostLikeService.java
+++ b/src/main/java/com/example/newsfeed/like/service/PostLikeService.java
@@ -25,59 +25,61 @@ public class PostLikeService implements LikeService{
     @Transactional
     public void createLike(Long memberId, Long postId) {
 
-        Post findPost = postService.findPostByIdOrElseThrow(postId);
+        Post findPost = validateNotPostAuthor(memberId, postId);
 
-        if (findPost.getMember().getId().equals(memberId)) {
-            throw new RuntimeException("본인이 작성한 게시글에 좋아요를 누를 수 없다.");
-        }
+        Optional<PostLike> optionalPostLike = postLikeRepository.findByMemberIdAndPostId(memberId, findPost.getId());
 
-        // post-like 테이블에 좋아요 기록이 있는지 없는지 확인
-        // 있을때 상태가 true 이다 --> 이미 좋아요를 누른 상태
-        // 있을때 상태가 false 이다 --> 좋아요를 해제한 상태(좋아요를 누를 수 있음)
-        // 없을때 --> 처음 좋아요를 누른 상태 (좋아요를 누를 수 있음)
-
-        Optional<PostLike> optionalPostLike = postLikeRepository.findPostLikeByMember_IdAndPost_Id(memberId, postId);
-
+        /*
+        post-like 테이블에 좋아요 기록이 있는지 없는지 확인
+        (1) 있을 때 상태가 true 이다 --> 이미 좋아요를 누른 상태
+        (2) 있을 때 상태가 false 이다 --> 좋아요를 해제한 상태 (좋아요를 누를 수 있음)
+        (3) 없을 때 --> 처음 좋아요를 누른 상태 (좋아요를 누를 수 있음)
+         */
         if (optionalPostLike.isPresent()) {
             PostLike findPostLike = optionalPostLike.get();
 
             if (findPostLike.getLikeStatus() == LikeStatus.LIKE) {
-                throw new RuntimeException("이미 좋아요를 누른 상태입니다.");
+                throw new RuntimeException("이미 좋아요를 누른 상태입니다.");    // (1)
             }
-
-            findPostLike.updateLikeStatus(LikeStatus.LIKE);
+            findPostLike.updateLikeStatus(LikeStatus.LIKE);             // (2)
             return;
         }
-
-        Member findMember = memberService.findActiveMemberByIdOrElseThrow(memberId);
-
-        PostLike postLike = new PostLike(findMember, findPost);
-        postLikeRepository.save(postLike);
+        PostLike postLike = new PostLike(new Member(memberId), findPost);
+        postLikeRepository.save(postLike);                              // (3)
     }
 
     @Override
     @Transactional
     public void deleteLike(Long memberId, Long postId) {
 
+        Post findPost = validateNotPostAuthor(memberId, postId);
+
+        /*
+        post-like 테이블에 좋아요 기록이 있는지 없는지 확인
+        (1) 있을 때 상태가 true 이다 --> 이미 좋아요를 누른 상태 (좋아요 취소 가능)
+        (2) 있을 때 상태가 false 이다 --> 좋아요를 해제한 상태
+        (3) 없을 때 --> 좋아요를 한 적이 없음
+         */
+
+        PostLike findPostLike = findByMemberAndPostOrElseThrow(memberId, findPost.getId());   // (3)
+
+        if (findPostLike.getLikeStatus() == LikeStatus.NOT_LIKE) {
+            throw new RuntimeException("이미 좋아요 해제를 한 게시물 입니다.");                // (2)
+        }
+        findPostLike.updateLikeStatus(LikeStatus.NOT_LIKE);                             // (1)
+    }
+
+    private Post validateNotPostAuthor(Long memberId, Long postId) {
         Post findPost = postService.findPostByIdOrElseThrow(postId);
 
         if (findPost.getMember().getId().equals(memberId)) {
-            throw new RuntimeException("본인이 작성한 게시글에 좋아요를 해제할 수 없다.");
+            throw new RuntimeException("본인이 작성한 게시글에 좋아요/좋아요 취소를 누를 수 없다.");
         }
-
-        Member findMember = memberService.findActiveMemberByIdOrElseThrow(memberId);
-
-        PostLike findPostLike = findPostLikeByMember_IdAndPost_IdOrElseThrow(findMember.getId(), findPost.getId());
-
-        if (findPostLike.getLikeStatus() == LikeStatus.NOT_LIKE) {
-            throw new RuntimeException("이미 좋아요 해제를 한 게시물 입니다.");
-        }
-
-        findPostLike.updateLikeStatus(LikeStatus.NOT_LIKE);
+        return findPost;
     }
 
-    private PostLike findPostLikeByMember_IdAndPost_IdOrElseThrow(Long memberId, Long postId) {
-        return postLikeRepository.findPostLikeByMember_IdAndPost_Id(memberId, postId).orElseThrow(
+    private PostLike findByMemberAndPostOrElseThrow(Long memberId, Long postId) {
+        return postLikeRepository.findByMemberIdAndPostId(memberId, postId).orElseThrow(
                 () -> new RuntimeException("좋아요 기록 존재하지 않음")
         );
     }

--- a/src/main/java/com/example/newsfeed/post/dto/PostResponseDto.java
+++ b/src/main/java/com/example/newsfeed/post/dto/PostResponseDto.java
@@ -16,6 +16,7 @@ public class PostResponseDto {
     private final String nickname;
     private final String image;
     private final String contents; // 누락된 contents 추가
+    private final int likeCount;
     private final LocalDateTime createdAt;
     private final LocalDateTime modifiedAt;
 
@@ -37,11 +38,12 @@ public class PostResponseDto {
     feat/post-read 브랜치
     PostResponseDto 생성자
     */
-    public PostResponseDto(Long id, String nickname, String contents, String image, LocalDateTime createdAt, LocalDateTime modifiedAt){
+    public PostResponseDto(Long id, String nickname, String contents, String image, int likeCount, LocalDateTime createdAt, LocalDateTime modifiedAt){
         this.id = id;
         this.nickname = nickname;
         this.contents = contents;
         this.image = image;
+        this.likeCount = likeCount;
         this.createdAt = createdAt;
         this.modifiedAt = modifiedAt;
     }
@@ -54,7 +56,15 @@ public class PostResponseDto {
     */
     public static PostResponseDto toDto(Post post){
         Member writer = post.getMember(); // Post 클래스의 멤버변수 private Member member에 접근!!
-        return new PostResponseDto(post.getId(), writer.getNickname(), post.getContents(), post.getImage(), post.getCreatedAt(), post.getModifiedAt());
+        return new PostResponseDto(
+                post.getId(),
+                writer.getNickname(),
+                post.getContents(),
+                post.getImage(),
+                post.getPostLikeList().size(),
+                post.getCreatedAt(),
+                post.getModifiedAt()
+        );
     }
 
 }

--- a/src/main/java/com/example/newsfeed/post/entity/Post.java
+++ b/src/main/java/com/example/newsfeed/post/entity/Post.java
@@ -31,7 +31,7 @@ public class Post extends BaseDateTime {
     @JoinColumn(name = "member_id")
     private Member member;
 
-    @OneToMany(mappedBy = "post")
+    @OneToMany(mappedBy = "post", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     List<PostLike> postLikeList = new ArrayList<>();
 
     public Post(String image, String contents, Member member) {

--- a/src/main/java/com/example/newsfeed/post/entity/Post.java
+++ b/src/main/java/com/example/newsfeed/post/entity/Post.java
@@ -1,10 +1,14 @@
 package com.example.newsfeed.post.entity;
 
 import com.example.newsfeed.global.entity.BaseDateTime;
+import com.example.newsfeed.like.entity.PostLike;
 import com.example.newsfeed.member.entity.Member;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
+
+import java.util.ArrayList;
+import java.util.List;
 
 
 @Getter
@@ -26,6 +30,9 @@ public class Post extends BaseDateTime {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
+
+    @OneToMany(mappedBy = "post")
+    List<PostLike> postLikeList = new ArrayList<>();
 
     public Post(String image, String contents, Member member) {
         this.image = image;

--- a/src/main/java/com/example/newsfeed/post/service/PostService.java
+++ b/src/main/java/com/example/newsfeed/post/service/PostService.java
@@ -104,7 +104,7 @@ public class PostService {
         postRepository.deleteById(postId);
     }
 
-    private Post findPostByIdOrElseThrow(Long postId) {
+    public Post findPostByIdOrElseThrow(Long postId) {
         return postRepository.findById(postId).orElseThrow(
                 () -> new IllegalArgumentException("해당 ID 찾을 수 없음")
         );


### PR DESCRIPTION
좋아요/좋아요 해제 부분을 구현해보았습니다.

Member와 Post로 테이블 조회 및 작성을 할 예정이었으나
세션에 있는 id를 사용할 경우 따로 Member조회 쿼리를 덜 실행시킬 수 있는 장점이 있다는 것을 알게 되었습니다.

PostLike 엔티티와 CommentLike 엔티티를 모두 구현했으니, 댓글 좋아요를 맡은 분께서 수정하시면 되겠습니다.

먼저 PR올린 뒤 리뷰를 받고, 각 게시물의 좋아요 갯수를 확인 할 수 있는 필드를 만드는 것도 좋을 것 같습니다.
게시글 조회부분이 merge가 되면 수정하겠습니다. 