### PR TITLE
Feat/member read

### DIFF
--- a/src/main/java/com/example/newsfeed/member/controller/MemberController.java
+++ b/src/main/java/com/example/newsfeed/member/controller/MemberController.java
@@ -102,9 +102,9 @@ public class MemberController {
      */
     @LoginRequired // 로그인을 안하면 LoginIntercepter.java 클래스를 통해 예외 발생 throw new RuntimeException("로그인 필요")
     @GetMapping
-    public ResponseEntity<FindMyMemberDto> findMyMember(HttpServletRequest httpServletRequest)
+    public ResponseEntity<FindMyMemberDto> findMyMember(@SessionAttribute(name ="member") SessionMemberDto currSession)
     {
-        FindMyMemberDto findMyMemberDto = memberService.findMyMember(httpServletRequest);
+        FindMyMemberDto findMyMemberDto = memberService.findMyMember(currSession);
 
         return new ResponseEntity<>(findMyMemberDto, HttpStatus.OK); // status 200
     }

--- a/src/main/java/com/example/newsfeed/member/controller/MemberController.java
+++ b/src/main/java/com/example/newsfeed/member/controller/MemberController.java
@@ -5,6 +5,7 @@ import com.example.newsfeed.global.entity.SessionMemberDto;
 import com.example.newsfeed.member.dto.MemberRequestDto;
 import com.example.newsfeed.member.dto.MemberResponseDto;
 import com.example.newsfeed.member.dto.deleteRequestDto;
+import com.example.newsfeed.member.dto.findmemberdto.FindMemberDto;
 import com.example.newsfeed.member.dto.updatePasswordRequestDto;
 import com.example.newsfeed.member.dto.updatedto.UpdateMemberProfileRequestDto;
 import com.example.newsfeed.member.dto.updatedto.UpdateMemberProfileResponseDto;
@@ -78,4 +79,23 @@ public class MemberController {
 
         return new ResponseEntity<>(HttpStatus.OK);
     }
+
+
+    /*
+    feat/member-read 브랜치
+    본인이나 다른사람의 유저프로필을 조회하는 메서드
+
+     */
+    @GetMapping("/{memberId}")
+    public ResponseEntity<FindMemberDto> findMemberById(@PathVariable Long memberId)
+    {
+        FindMemberDto findMemberDto = memberService.findMemberById(memberId);
+
+        return new ResponseEntity<>(findMemberDto, HttpStatus.OK);
+    }
+
+
+
+
+
 }

--- a/src/main/java/com/example/newsfeed/member/controller/MemberController.java
+++ b/src/main/java/com/example/newsfeed/member/controller/MemberController.java
@@ -85,7 +85,6 @@ public class MemberController {
     /*
     feat/member-read 브랜치
     다른사람의 멤버프로필을 조회하는 메서드
-
      */
     @GetMapping("/{memberId}")
     public ResponseEntity<FindMemberDto> findMemberById(@PathVariable Long memberId)
@@ -99,17 +98,16 @@ public class MemberController {
     /*
     feat/member-read 브랜치
     본인의 멤버프로필을 조회하는 메서드
-
+    현재 로그인한 http세션을 서비스단에 전달한다
      */
+    @LoginRequired // 로그인을 안하면 LoginIntercepter.java 클래스를 통해 예외 발생 throw new RuntimeException("로그인 필요")
     @GetMapping
-    public ResponseEntity<FindMyMemberDto> findMyMember()
+    public ResponseEntity<FindMyMemberDto> findMyMember(HttpServletRequest httpServletRequest)
     {
-        FindMyMemberDto findMyMemberDto = memberService.findMyMember();
+        FindMyMemberDto findMyMemberDto = memberService.findMyMember(httpServletRequest);
 
-        return new ResponseEntity<>(findMyMemberDto, HttpStatus.OK);
+        return new ResponseEntity<>(findMyMemberDto, HttpStatus.OK); // status 200
     }
-
-
 
 
 }

--- a/src/main/java/com/example/newsfeed/member/controller/MemberController.java
+++ b/src/main/java/com/example/newsfeed/member/controller/MemberController.java
@@ -5,7 +5,7 @@ import com.example.newsfeed.global.entity.SessionMemberDto;
 import com.example.newsfeed.member.dto.MemberRequestDto;
 import com.example.newsfeed.member.dto.MemberResponseDto;
 import com.example.newsfeed.member.dto.deleteRequestDto;
-import com.example.newsfeed.member.dto.findmemberdto.FindMemberDto;
+import com.example.newsfeed.member.dto.findmemberdto.*;
 import com.example.newsfeed.member.dto.updatePasswordRequestDto;
 import com.example.newsfeed.member.dto.updatedto.UpdateMemberProfileRequestDto;
 import com.example.newsfeed.member.dto.updatedto.UpdateMemberProfileResponseDto;
@@ -84,7 +84,7 @@ public class MemberController {
 
     /*
     feat/member-read 브랜치
-    본인이나 다른사람의 유저프로필을 조회하는 메서드
+    다른사람의 멤버프로필을 조회하는 메서드
 
      */
     @GetMapping("/{memberId}")
@@ -95,6 +95,19 @@ public class MemberController {
         return new ResponseEntity<>(findMemberDto, HttpStatus.OK);
     }
 
+
+    /*
+    feat/member-read 브랜치
+    본인의 멤버프로필을 조회하는 메서드
+
+     */
+    @GetMapping
+    public ResponseEntity<FindMyMemberDto> findMyMember()
+    {
+        FindMyMemberDto findMyMemberDto = memberService.findMyMember();
+
+        return new ResponseEntity<>(findMyMemberDto, HttpStatus.OK);
+    }
 
 
 

--- a/src/main/java/com/example/newsfeed/member/dto/findmemberdto/FindMemberDto.java
+++ b/src/main/java/com/example/newsfeed/member/dto/findmemberdto/FindMemberDto.java
@@ -1,0 +1,27 @@
+package com.example.newsfeed.member.dto.findmemberdto;
+
+import lombok.Getter;
+import java.time.LocalDateTime;
+
+
+@Getter
+public class FindMemberDto {
+
+    private final Long id;
+    private final String nickname;
+    private final String email;
+    private final String info;
+    private final String mbit;
+    private final LocalDateTime createdAt;
+
+
+    public FindMemberDto(Long id, String nickname, String email, String info, String mbit, LocalDateTime createdAt){
+        this.id = id;
+        this.nickname = nickname;
+        this.email = email;
+        this.info = info;
+        this.mbit = mbit;
+        this.createdAt = createdAt;
+    }
+
+}

--- a/src/main/java/com/example/newsfeed/member/dto/findmemberdto/FindMyMemberDto.java
+++ b/src/main/java/com/example/newsfeed/member/dto/findmemberdto/FindMyMemberDto.java
@@ -1,0 +1,31 @@
+package com.example.newsfeed.member.dto.findmemberdto;
+
+import lombok.Getter;
+import java.time.LocalDateTime;
+
+
+@Getter
+public class FindMyMemberDto {
+
+    private final Long id;
+    private final String username;
+    private final String nickname;
+    private final String email;
+    private final String info;
+    private final String mbit;
+    private final LocalDateTime createdAt;
+    private final LocalDateTime modifiedAt;
+
+
+    public FindMyMemberDto(Long id, String username, String nickname, String email, String info, String mbit, LocalDateTime createdAt, LocalDateTime modifiedAt){
+        this.id = id;
+        this.username = username;
+        this.nickname = nickname;
+        this.email = email;
+        this.info = info;
+        this.mbit = mbit;
+        this.createdAt = createdAt;
+        this.modifiedAt = modifiedAt;
+    }
+
+}

--- a/src/main/java/com/example/newsfeed/member/service/MemberService.java
+++ b/src/main/java/com/example/newsfeed/member/service/MemberService.java
@@ -3,6 +3,7 @@ package com.example.newsfeed.member.service;
 import com.example.newsfeed.global.config.PasswordEncoder;
 import com.example.newsfeed.global.entity.SessionMemberDto;
 import com.example.newsfeed.member.dto.MemberResponseDto;
+import com.example.newsfeed.member.dto.findmemberdto.FindMemberDto;
 import com.example.newsfeed.member.dto.updatePasswordRequestDto;
 import com.example.newsfeed.member.dto.updatedto.UpdateMemberProfileRequestDto;
 import com.example.newsfeed.member.dto.updatedto.UpdateMemberProfileResponseDto;
@@ -10,8 +11,10 @@ import com.example.newsfeed.member.entity.Member;
 import com.example.newsfeed.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.util.Optional;
 
@@ -153,4 +156,32 @@ public class MemberService {
 
         return findMember;
     }
+
+    /*
+    feat/member-read
+    멤버 id로 유저 프로필 조회
+     */
+    public FindMemberDto findMemberById(Long memberId){
+
+        Optional<Member> optionalMember = memberRepository.findById(memberId);
+
+        // 조회에 실패할 경우
+        if(optionalMember.isEmpty()){
+            // status 404 Not Found
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, memberId + "의 id값을 갖는 유저는 존재하지 않습니다.");
+        }
+
+        Member findMember = optionalMember.get();
+
+        return new FindMemberDto(findMember.getId(), findMember.getNickname(), findMember.getEmail(), findMember.getInfo(), findMember.getMbti(), findMember.getCreatedAt());
+
+    }
+
+
+
+
+
+
+
+
 }

--- a/src/main/java/com/example/newsfeed/member/service/MemberService.java
+++ b/src/main/java/com/example/newsfeed/member/service/MemberService.java
@@ -9,6 +9,8 @@ import com.example.newsfeed.member.dto.updatedto.UpdateMemberProfileRequestDto;
 import com.example.newsfeed.member.dto.updatedto.UpdateMemberProfileResponseDto;
 import com.example.newsfeed.member.entity.Member;
 import com.example.newsfeed.member.repository.MemberRepository;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -215,29 +217,30 @@ public class MemberService {
     }
 
 
+     /*
+       feat/member-read
+       본인 유저 프로필 조회 메서드
+       MemberController.java -> findMyMember 메서드 상단에 @LoginRequired custom annotaion으로 로그인 세션이
+       null이면(즉 로그인을 안한 비회원 상태라면) 해당 기능에 접근을 막아 해당 코드에서 예외처리를 따로 안해도 된다.
+    */
+    public FindMyMemberDto findMyMember(HttpServletRequest httpServletRequest){
+
+        // 현재 로그인 세션을 얻기
+        HttpSession session = httpServletRequest.getSession(false);
+        SessionMemberDto currMemberSession = (SessionMemberDto) session.getAttribute("member");
 
 
-    /*
-    feat/member-read
-    본인 유저 프로필 조회 메서드
-
-    만드는중입니당 underconstruction!!
-     */
-    public FindMyMemberDto findMyMember(){
-
-        // 로그인 세션에서 본인 memberId받아서 밑에 넣는 코드 만들꺼임
-        Optional<Member> optionalMember = memberRepository.findActiveMemberById(memberId);
+        // 획득한 로그인 세션에서 본인 memberId를 통해 DB에서 유저프로필 조회
+        Optional<Member> optionalMember = memberRepository.findActiveMemberById(currMemberSession.getId());
 
         /*
-        본인 유저프로필을 조회하는대 다른사람 memberId를 조회할리도 없고
-        예외처리 만들어봤자 시간낭비라서 안만듦ㅋ
+        MemberController.java -> findMyMember 메서드 상단에 @LoginRequired custom annotaion으로 로그인 세션이
+        null이면(즉 로그인을 안한 비회원 상태라면) 메서드 실행을 막아 현재 이 코드에서 예외처리를 따로 안해도 된다.
          */
 
-        Member findMyMember = optionalMember.get(); // 내 유저 프로필이니깐 isPresent()로 검사 안해도 됨
-        return new FindMyMemberDto(findMyMember.getId(), findMyMember.getNickname(), findMyMember.getEmail(), findMyMember.getInfo(), findMyMember.getMbti(), findMyMember.getCreatedAt());
-
+        Member findMyMember = optionalMember.get(); // 내 유저 프로필이니깐 isPresent()로 검사 안해도 상관없다
+        return new FindMyMemberDto(findMyMember.getId(),findMyMember.getUsername(), findMyMember.getNickname(), findMyMember.getEmail(), findMyMember.getInfo(), findMyMember.getMbti(), findMyMember.getCreatedAt(), findMyMember.getModifiedAt());
     }
-
 
 
 }

--- a/src/main/java/com/example/newsfeed/member/service/MemberService.java
+++ b/src/main/java/com/example/newsfeed/member/service/MemberService.java
@@ -16,6 +16,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.bind.annotation.SessionAttribute;
 import org.springframework.web.server.ResponseStatusException;
 
 import java.util.Optional;
@@ -186,33 +187,35 @@ public class MemberService {
      */
     public FindMemberDto findMemberById(Long memberId){
 
-        Optional<Member> optionalMember = memberRepository.findActiveMemberById(memberId);
+        // 람다식으로 깔끔하게 예외처리와 sql조회를 동시에~~ made by queenriwon
+        Member member = memberRepository.findActiveMemberById(memberId).orElseThrow( () -> new ResponseStatusException(HttpStatus.NOT_FOUND, memberId + "의 memberId값을 갖는 유저는 탈퇴했거나 존재하지 않습니다."));
 
+        // 지우긴 싫어서 주석으로 남기는대 지우고 싶으면 지우십쇼zzzz 아래 코드들이 람다식으로 다 쓸모가 없어져 부렸으
+        //Optional<Member> optionalMember = memberRepository.findActiveMemberById(memberId);
 
         /* 멤버 조회에 실패한 경우
          memberRepository.findActiveMemberById(memberId);에서
          MemberRepository.java는 interface라 해당 구역에서 예외처리를 할 수가 없다 (정말사실인지 따져봐야됨)
          따라서 현 위치인 if문에서 예외처리를 해준다
         */
-        if(optionalMember.isEmpty()){
+
+        //if(optionalMember.isEmpty()){
             /*
              DB에서 조회하고자 하는 memberId 튜플의 isDelete 애트리뷰트가 true인 경우 MemberRepository.java의
              findActiveMemberByEmail 메서드는 null 값을 optionalMember에 return 할것이다.
              그 다음 인스턴스인 optaionalMember를 여기 if문에서 isEmpty()메서드로 optionalMember == null 인지 체크 한다
              */
             // status 404 Not Found 예외
-            throw new ResponseStatusException(HttpStatus.NOT_FOUND, memberId + "의 memberId값을 갖는 유저는 탈퇴했거나 존재하지 않습니다.");
-        }
+            //throw new ResponseStatusException(HttpStatus.NOT_FOUND, memberId + "의 memberId값을 갖는 유저는 탈퇴했거나 존재하지 않습니다.");
+        //}
 
-        /* 멤버 조회에 성공한 경우
+
+        /* 멤버 조회에 성공한 경우 (일반적인 상황)
         Member 인스턴스를 생성후 new연산자로 생성된 FindMemberDto에 @Getter를 이용하여
         데이터를 저장하고 caller인 MemberController에 FindMemberDto의 reference를 return한다
         */
-        else{
-
-            Member findMember = optionalMember.get();
-            return new FindMemberDto(findMember.getId(), findMember.getNickname(), findMember.getEmail(), findMember.getInfo(), findMember.getMbti(), findMember.getCreatedAt());
-        }
+        //Member findMember = member;
+        return new FindMemberDto(member.getId(), member.getNickname(), member.getEmail(), member.getInfo(), member.getMbti(), member.getCreatedAt());
 
     }
 
@@ -223,15 +226,12 @@ public class MemberService {
        MemberController.java -> findMyMember 메서드 상단에 @LoginRequired custom annotaion으로 로그인 세션이
        null이면(즉 로그인을 안한 비회원 상태라면) 해당 기능에 접근을 막아 해당 코드에서 예외처리를 따로 안해도 된다.
     */
-    public FindMyMemberDto findMyMember(HttpServletRequest httpServletRequest){
+    public FindMyMemberDto findMyMember(SessionMemberDto currSession){
 
-        // 현재 로그인 세션을 얻기
-        HttpSession session = httpServletRequest.getSession(false);
-        SessionMemberDto currMemberSession = (SessionMemberDto) session.getAttribute("member");
-
-
-        // 획득한 로그인 세션에서 본인 memberId를 통해 DB에서 유저프로필 조회
-        Optional<Member> optionalMember = memberRepository.findActiveMemberById(currMemberSession.getId());
+        // MemberController에서 전달받은 현재 로그인 세션에서 getId()를 통해 DB에서 유저프로필 조회
+        // Member member = memberRepository.findActiveMemberById(memberId).orElseThrow( () -> new ResponseStatusException(HttpStatus.NOT_FOUND, memberId + "의 memberId값을 갖는 유저는 탈퇴했거나 존재하지 않습니다."));
+        // 위의 코드를 사용해서 예외처리와 조회를 동시에 할 수도있다
+        Optional<Member> optionalMember = memberRepository.findActiveMemberById(currSession.getId());
 
         /*
         MemberController.java -> findMyMember 메서드 상단에 @LoginRequired custom annotaion으로 로그인 세션이

--- a/src/main/java/com/example/newsfeed/post/dto/PostResponseDto.java
+++ b/src/main/java/com/example/newsfeed/post/dto/PostResponseDto.java
@@ -16,22 +16,9 @@ public class PostResponseDto {
     private final Long id;
     private final String nickname;
     private final String image;
-    private final String contents; // 누락된 contents 추가
+    private final String contents;
     private final LocalDateTime createdAt;
     private final LocalDateTime modifiedAt;
-
-
-    /*
-    feat/post-create 브랜치에서 만든 생성자
-    contents가 누락되어 있습니다
-    public PostResponseDto(Long id, String nickname, String image, LocalDateTime createdAt, LocalDateTime modifiedAt){
-        this.id = id;
-        this.nickname = nickname;
-        this.image = image;
-        this.createdAt = createdAt;
-        this.modifiedAt = modifiedAt;
-    }
-    */
 
 
     /*

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,8 +1,8 @@
 spring.application.name=news-feed
 
 spring.datasource.url=jdbc:mysql://localhost:3306/newsfeed
-spring.datasource.username=root
-spring.datasource.password=jieun4711@
+spring.datasource.username=zen
+spring.datasource.password=1234!@abcABC
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 
 spring.jpa.hibernate.ddl-auto=update


### PR DESCRIPTION
feat/member-read 본인 타인 유저프로필 기본 기능 구현 완료하였습니다.
본인 유저프로필 조회할때 현재 로그인한 http session에서 memberId를 받아와 findActiveMemberById
에 전달하는것으로 구현하였습니다. MemberController에서 @LoginRequired로 예외처리를 하기때문에
MemberService에 있는 findMyMember에서는 따로 예외처리를 안해도 될거같습니다.