### PR TITLE
Fix(logout): 비로그인 세션에서 로그아웃시 예외처리가 되어지도록 코드 패치

### DIFF
--- a/src/main/java/com/example/newsfeed/member/controller/AuthenticationController.java
+++ b/src/main/java/com/example/newsfeed/member/controller/AuthenticationController.java
@@ -1,5 +1,6 @@
 package com.example.newsfeed.member.controller;
 
+import com.example.newsfeed.global.annotation.LoginRequired;
 import com.example.newsfeed.global.dto.SessionMemberDto;
 import com.example.newsfeed.global.exception.ApiResponseDto;
 import com.example.newsfeed.global.exception.ApiResponseDtoImpl;
@@ -58,6 +59,7 @@ public class AuthenticationController {
         throw new NotFoundException.MemberNotFoundException(MEMBER_NOT_FOUND);
     }
 
+    @LoginRequired
     @GetMapping("/logout")
     public ResponseEntity<ApiResponseDto<Void>> logoutMember(HttpServletRequest httpServletRequest) {
         HttpSession session = httpServletRequest.getSession(false);

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,8 +1,8 @@
 spring.application.name=news-feed
 
 spring.datasource.url=jdbc:mysql://localhost:3306/newsfeed
-spring.datasource.username=root
-spring.datasource.password=Plqafgh12!
+spring.datasource.username=zen
+spring.datasource.password=1234!@abcABC
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 
 spring.jpa.hibernate.ddl-auto=update


### PR DESCRIPTION
logoutMember 메서드에 커스텀 annotaion @LoginRequired를 추가함으로서 비로그인 세션은 해당 메서드의 사용을 못하게한다